### PR TITLE
MANTA-4582 Spurious fast protocol errors on CRC compatibility in muskie log

### DIFF
--- a/lib/fast_protocol.js
+++ b/lib/fast_protocol.js
@@ -15,6 +15,7 @@
 var mod_assertplus = require('assert-plus');
 var mod_crc = require('crc');
 var mod_extsprintf = require('extsprintf');
+var mod_microtime = require('microtime');
 var mod_old_crc = require('oldcrc');
 var mod_stream = require('stream');
 var mod_util = require('util');
@@ -184,7 +185,8 @@ function fastMessageEncode(msg, default_crc_mode)
 	mod_assertplus.optionalNumber(msg.crc_mode, 'msg.crc_mode');
 
 	if (default_crc_mode && default_crc_mode !== FAST_CHECKSUM_V1 &&
-	    default_crc_mode !== FAST_CHECKSUM_V2) {
+	    default_crc_mode !== FAST_CHECKSUM_V2 &&
+	    default_crc_mode !== FAST_CHECKSUM_V1_V2) {
 		mod_assertplus.fail('encountered invalid CRC mode ' +
 		    default_crc_mode);
 	}
@@ -200,11 +202,25 @@ function fastMessageEncode(msg, default_crc_mode)
 
 	data_encoded = JSON.stringify(msg.data);
 
+	var match_result;
+
 	var crc_mode = msg.crc_mode || default_crc_mode || FAST_CHECKSUM_V1;
 	if (crc_mode === FAST_CHECKSUM_V1) {
-		crc16 = mod_old_crc.crc16(data_encoded);
+		match_result = findMatchingCrc(msg.data);
+		crc16 = match_result.crc;
+		data_encoded = match_result.data;
 	} else if (crc_mode === FAST_CHECKSUM_V2) {
 		crc16 = mod_crc.crc16(data_encoded);
+	} else if (crc_mode === FAST_CHECKSUM_V1_V2) {
+		// This is the unfortunate case where we cannot determine which
+		// version of the CRC library should be used to encode the
+		// message. Since we do not know what the intended message
+		// recipient can handle we attempt to manipulate the message so
+		// that the calculated CRC matches with both versions of the
+		// library.
+		match_result = findMatchingCrc(msg.data);
+		crc16 = match_result.crc;
+		data_encoded = match_result.data;
 	} else {
 		throw (new VError('fastMessageEncode: unsupported CRC mode: ' +
 		    crc_mode));
@@ -220,6 +236,36 @@ function fastMessageEncode(msg, default_crc_mode)
 	buffer.writeUInt32BE(datalen, FP_OFF_DATALEN);
 	buffer.write(data_encoded, FP_OFF_DATA, datalen, 'utf8');
 	return (buffer);
+}
+
+/*
+ * Attempt to find a data encoding for a Fast message data where the CRC16 code
+ * matches for both version of the CRC library. The old CRC library version is
+ * buggy, but there are cases where the calculated CRC for a message matches
+ * that calculated by the corrected CRC library version.
+ *
+ *     data             The string representation of the Fast message data.
+ */
+function findMatchingCrc(data) {
+	var matching_crc = mod_old_crc.crc16(data);
+	var data_encoded = JSON.stringify(data);
+
+	for (var i = 0; i < 500000; i++) {
+		var crc16_old = mod_old_crc.crc16(data_encoded);
+		var crc16_new = mod_crc.crc16(data_encoded);
+		if (crc16_old === crc16_new) {
+			matching_crc = crc16_old;
+			break;
+		} else {
+			data.m.uts = mod_microtime.now();
+			data_encoded = JSON.stringify(data);
+		}
+	}
+
+	return {
+		crc: matching_crc,
+		data: data_encoded
+	};
 }
 
 /*
@@ -252,6 +298,9 @@ function validateCrc(crcMode, headerCrc, data) {
 		    v2CalculatedCrc !== headerCrc) {
 			error = crcValidationError(crcMode, headerCrc,
 			    v1CalculatedCrc, v2CalculatedCrc);
+		} else if (v1CalculatedCrc === headerCrc &&
+		    v2CalculatedCrc === headerCrc) {
+			decodedCrcMode = FAST_CHECKSUM_V1_V2;
 		} else if (v2CalculatedCrc === headerCrc) {
 			decodedCrcMode = FAST_CHECKSUM_V2;
 		} else {


### PR DESCRIPTION
The changes from [this](https://github.com/joyent/node-fast/commit/7678aa13604d6ae903676764f68ee3db2c52dea4) commit to help provide a bridge for existing applications using `node-fast` to upgrade to a version of the `node-crc` library that has corrections for some earlier bugs did not account for the fact that there are cases where the buggy version of `node-crc` does calculate correct CRC values for some messages.  In thiese cases the library used to encode a received Fast message cannot be determined by decoding the message and therefore it cannot be known which version of the CRC library to use to encode a response. This change detects these cases and makes an attempts to find a message whose CRC calculation matches for both versions of the CRC library. If no match can be found within a bounded number of attempts the fallback of the older version of the library is used instead.