### PR TITLE
TRITON-2142 Add postgresql notification support to Moray

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 
 None yet.
 
+## v3.1.0
+
+* Added fsr_context.addSocketEndListener() method so that long running RPC
+  calls can tell when the client socket has ended.
+
 ## v3.0.1
 
 * Add support for a `metricLabels` option when creating node-fast clients. This

--- a/lib/fast_client.js
+++ b/lib/fast_client.js
@@ -711,8 +711,8 @@ FastClient.prototype.requestComplete = function (request)
 		latency = mod_jsprim.hrtimeMillisec(diff);
 
 		/*
-		 * Track the requested RPC method and add labels that were requested by
-		 * the client creator.
+		 * Track the requested RPC method and add labels that were
+		 * requested by the client creator.
 		 */
 		labels = mod_jsprim.mergeObjects(this.fc_metric_labels,
 		    { 'rpcMethod': request.frq_rpcmethod },

--- a/lib/fast_server.js
+++ b/lib/fast_server.js
@@ -1200,6 +1200,16 @@ function FastRpcServerRequest(args)
 	this.fsr_context.methodName = function ctxMethodName() {
 		return (request.fsr_rpcmethod);
 	};
+	/*
+	 * This socket end listener is provided for long-lived clients (e.g.
+	 * streaming clients) that need to know when the underlying request
+	 * socket has ended, otherwise they will not know when to end their
+	 * task.
+	 */
+	this.fsr_context.addSocketEndListener =
+			function ctxAddSocketEndListener(listener) {
+		request.fsr_conn.fc_socket.once('end', listener);
+	};
 	this.fsr_context.argv = function ctxArgv() {
 		/*
 		 * For clarity and debuggability, callers ought to avoid mucking

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "fast",
 	"description": "streaming JSON RPC over TCP",
-	"version": "3.0.1",
+	"version": "3.1.0",
 	"main": "./lib/fast.js",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
This will be used by the moray server for the postgresql listen (for notifications) call - where it can stream "notify" notifications.